### PR TITLE
Do not whitelist json keys for get_strex_transaction server reponse

### DIFF
--- a/target365_sdk/api_client.py
+++ b/target365_sdk/api_client.py
@@ -366,7 +366,7 @@ class ApiClient:
         response = self.client.get(self.STREX_TRANSACTIONS + '/' + transaction_id)
         response.raise_for_status()
 
-        return StrexTransaction(**response.json())
+        return StrexTransaction(validate_keys=False, **response.json())
 
     def delete_strex_transaction(self, transaction_id):
         """

--- a/target365_sdk/models/model.py
+++ b/target365_sdk/models/model.py
@@ -3,7 +3,7 @@ from abc import ABCMeta, abstractmethod
 class Model:
     __metaclass__ = ABCMeta
 
-    def __init__(self, **kwargs):
+    def __init__(self, validate_keys=True, **kwargs):
 
         args = self._init_preprocess(kwargs)
 
@@ -12,7 +12,7 @@ class Model:
 
         for key, value in args.items():
 
-            if key not in self._accepted_params():
+            if validate_keys and key not in self._accepted_params():
                 raise Exception('This model does not allow parameter `' + key + '`')
 
             setattr(self, key, value)


### PR DESCRIPTION
Currently, the SDK validates all keys in the server response against a whitelist in the model. This makes sense for input from the user - to give useful errors when the SDK is used incorrectly, but validating the server response like this makes it hard to add more information to the server response in the future without breaking existing clients.

This has already happened, which is why I created this fix (for example, eTag is now returned, and rejected by the model, so get_transaction does not work currently).

This change still uses the whitelist by default, but turns it off when returning data from get_strex_transaction.

(It probably needs to be done to other server responses as well, but I don't want to modify code I don't use/test).